### PR TITLE
Fix version constraint of rocketeer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	],
 	"require": {
 		"php": ">=5.4.0",
-		"anahkiasen/rocketeer": "2.0.*@dev",
+		"anahkiasen/rocketeer": "~2.0",
 		"illuminate/support": "~4.2",
 		"mcrumm/phlack": "0.5.*"
 	},


### PR DESCRIPTION
So it's no longer locked to `2.0` of rocketeer