### PR TITLE
Replace mcrumm/phlack with maknz/slack

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
 	"name": "rocketeers/rocketeer-slack",
 	"description": "Slack plugin for Rocketeer",
-  "license": "MIT",
-  "keywords": [
-    "rocketeer",
-    "deployment",
-    "slack",
-    "laravel"
-  ],
+	"license": "MIT",
+	"keywords": [
+		"rocketeer",
+		"deployment",
+		"slack",
+		"laravel"
+	],
 	"authors": [
 		{
 			"name": "Maxime Fabre",
@@ -18,7 +18,7 @@
 		"php": ">=5.4.0",
 		"anahkiasen/rocketeer": "2.0.*@dev",
 		"illuminate/support": "~4.2",
-		"mcrumm/phlack": "0.5.*"
+		"maknz/slack": "1.5.*"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -3,9 +3,9 @@
 return array(
 
 	// Slack room credentials
+	'url'      => '',
 	'username' => '',
 	'room'     => '',
-	'token'    => '',
 
 	// Message
 	// You can use the following variables :


### PR DESCRIPTION
Replaces soon-to-be-deprecated [mcrumm/phlack](https://github.com/mcrumm/phlack) with [maknz/slack](https://github.com/maknz/slack) (Superceeds #16).