### PR TITLE
Make the rocket emoji work

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -18,6 +18,6 @@ return array(
 	'after_rollback' => '{1} rolled back branch "{2}" on "{3}" to previous version ({4})',
 
 	// Default emoji to use as the bot's avatar
-	'emoji'   => 'rocket',
+	'emoji'   => ':rocket:',
 
 );


### PR DESCRIPTION
The current rocket emoji example does not work due to wrong format. This pull request makes the emoji work again.